### PR TITLE
cleaned up read-me docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
-/* Coolors Exported Palette - coolors.co/222222-313131-343a40-245c8e-949ea8 */
+/* STATIC SITE GENERATOR INFORMATION */
 
-/* HSL */
-$color1: hsla(0%, 0%, 13%, 1);
-$color2: hsla(0%, 0%, 19%, 1);
-$color3: hsla(210%, 10%, 23%, 1);
-$color4: hsla(208%, 60%, 35%, 1);
-$color5: hsla(210%, 10%, 62%, 1);
+/* To generate updated webpages from the associated files in this directory,
+simply run either of the following: */
 
-/* RGB */
-$color1: rgba(34, 34, 34, 1);
-$color2: rgba(49, 49, 49, 1);
-$color3: rgba(52, 58, 64, 1);
-$color4: rgba(36, 92, 142, 1);
-$color5: rgba(148, 158, 168, 1);
+build.sh
+build.py
+
+
+

--- a/docs/css/css_palette.md
+++ b/docs/css/css_palette.md
@@ -1,0 +1,16 @@
+
+/* Coolors Exported Palette - coolors.co/222222-313131-343a40-245c8e-949ea8 */
+
+/* HSL */
+$color1: hsla(0%, 0%, 13%, 1);
+$color2: hsla(0%, 0%, 19%, 1);
+$color3: hsla(210%, 10%, 23%, 1);
+$color4: hsla(208%, 60%, 35%, 1);
+$color5: hsla(210%, 10%, 62%, 1);
+
+/* RGB */
+$color1: rgba(34, 34, 34, 1);
+$color2: rgba(49, 49, 49, 1);
+$color3: rgba(52, 58, 64, 1);
+$color4: rgba(36, 92, 142, 1);
+$color5: rgba(148, 158, 168, 1);


### PR DESCRIPTION
Simply separated the CSS color palette data from the main README.md into its own file in the css directory.